### PR TITLE
Better Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,18 @@
-.PHONY: all
+.PHONY: all install uninstall
 
-all: install
+all: stallman.dat
+
+stallman.dat: stallman
+	strfile stallman stallman.dat
 
 install:
-	cp ./rms.cow /usr/share/cowsay/cows
-	strfile stallman stallman.dat
-	cp ./stallman /usr/share/fortune
-	cp ./rmssay /bin/
+	install -m644 rms.cow $(DESTDIR)/usr/share/cows
+	install -m644 stallman $(DESTDIR)/usr/share/fortune
+	install -m644 stallman.dat $(DESTDIR)/usr/share/fortune
+	install -m755 rmssay $(DESTDIR)/usr/local/bin
+
+uninstall:
+	rm $(DESTDIR)/usr/share/cows/rms.cow
+	rm $(DESTDIR)/usr/share/fortune/stallman
+	rm $(DESTDIR)/usr/share/fortune/stallman.dat
+	rm $(DESTDIR)/usr/local/bin/rmssay

--- a/Makefile
+++ b/Makefile
@@ -6,10 +6,10 @@ stallman.dat: stallman
 	strfile stallman stallman.dat
 
 install:
-	install -D -m644 rms.cow $(DESTDIR)/usr/share/cows
-	install -D -m644 stallman $(DESTDIR)/usr/share/fortune
-	install -D -m644 stallman.dat $(DESTDIR)/usr/share/fortune
-	install -D -m755 rmssay $(DESTDIR)/usr/local/bin
+	install -D -m644 rms.cow $(DESTDIR)/usr/share/cows/rms.cow
+	install -D -m644 stallman $(DESTDIR)/usr/share/fortune/stallman
+	install -D -m644 stallman.dat $(DESTDIR)/usr/share/fortune/stallman.dat
+	install -D -m755 rmssay $(DESTDIR)/usr/local/bin/rmssay
 
 uninstall:
 	rm $(DESTDIR)/usr/share/cows/rms.cow

--- a/Makefile
+++ b/Makefile
@@ -1,18 +1,20 @@
 .PHONY: all install uninstall
 
+PREFIX=/usr/local
+
 all: stallman.dat
 
 stallman.dat: stallman
 	strfile stallman stallman.dat
 
-install:
+install: stallman.dat
 	install -D -m644 rms.cow $(DESTDIR)/usr/share/cows/rms.cow
 	install -D -m644 stallman $(DESTDIR)/usr/share/fortune/stallman
 	install -D -m644 stallman.dat $(DESTDIR)/usr/share/fortune/stallman.dat
-	install -D -m755 rmssay $(DESTDIR)/usr/local/bin/rmssay
+	install -D -m755 rmssay $(DESTDIR)$(PREFIX)/bin/rmssay
 
 uninstall:
 	rm $(DESTDIR)/usr/share/cows/rms.cow
 	rm $(DESTDIR)/usr/share/fortune/stallman
 	rm $(DESTDIR)/usr/share/fortune/stallman.dat
-	rm $(DESTDIR)/usr/local/bin/rmssay
+	rm $(DESTDIR)$(PREFIX)/bin/rmssay

--- a/Makefile
+++ b/Makefile
@@ -6,10 +6,10 @@ stallman.dat: stallman
 	strfile stallman stallman.dat
 
 install:
-	install -m644 rms.cow $(DESTDIR)/usr/share/cows
-	install -m644 stallman $(DESTDIR)/usr/share/fortune
-	install -m644 stallman.dat $(DESTDIR)/usr/share/fortune
-	install -m755 rmssay $(DESTDIR)/usr/local/bin
+	install -D -m644 rms.cow $(DESTDIR)/usr/share/cows
+	install -D -m644 stallman $(DESTDIR)/usr/share/fortune
+	install -D -m644 stallman.dat $(DESTDIR)/usr/share/fortune
+	install -D -m755 rmssay $(DESTDIR)/usr/local/bin
 
 uninstall:
 	rm $(DESTDIR)/usr/share/cows/rms.cow


### PR DESCRIPTION
I'm planning on putting this to the AUR and I need a better Makefile for that. The new one includes the `uninstall` and `stallman.dat` targets. Compiling and installing is now `make` and `sudo make install`, uninstalling is `sudo make uninstall`. You can also define the `DESTDIR` variable.

It would be nice to add a license (see #2). Probably GPL, because GPL was written by rms.